### PR TITLE
Correcting the module name in iOS libraries.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+./gradlew clean
+./gradlew build
+
+zip -r build/RxCommon.zip ios/build/konan/libs/* common/build/libs/* js/build/libs/* jvm/build/libs/*

--- a/ios/build.gradle
+++ b/ios/build.gradle
@@ -14,6 +14,7 @@ apply plugin: 'konan'
 konanArtifacts {
     library('RxCommon', targets: ['iphone', 'iphone_sim', 'macbook', 'wasm32', 'linux', 'android_arm64', 'android_arm32']) {
         enableMultiplatform true
+        extraOpts '-module_name', ''
     }
 }
 


### PR DESCRIPTION
It was prefixing RxCommon in the header files.